### PR TITLE
fix: mover envío masivo de emails a 'Ver facturas' y reforzar invaria…

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -77,8 +77,9 @@ REQUIRE:
 ## Testing And Validation Expectations
 
 REQUIRE:
-- For backend changes, run targeted pytest for touched modules when feasible.
-- For frontend changes, run `npm run lint` and `npm run build` when feasible.
+- Run tests/checks via Docker/Make targets in this repository (do not rely on host Python/Node).
+- For backend changes, run `make test-backend` (or `make test`) when feasible.
+- For frontend changes, run `make lint-frontend` and `make build-frontend` when feasible.
 - Verify tenant isolation and permissions on changed paths.
 
 ## Branch And Release Governance
@@ -98,11 +99,11 @@ PREFER:
 - Separate tooling/governance changes from product logic changes.
 
 Useful commands:
-- Backend all tests: `cd backend && python -m pytest`
-- Backend single file: `cd backend && python -m pytest tests/test_facturas.py -v`
-- Backend single test: `cd backend && python -m pytest tests/test_facturas.py::TestBulkDeleteFacturas::test_bulk_delete -v`
-- Frontend lint: `cd frontend && npm run lint`
-- Frontend build: `cd frontend && npm run build`
+- Backend all tests (Docker): `make test-backend`
+- Backend default suite (Docker): `make test`
+- Frontend lint (Docker): `make lint-frontend`
+- Frontend build (Docker): `make build-frontend`
+- Full pre-push checks (Docker): `make pre-push`
 
 ## Fast File Map
 - `backend/app/api/facturas.py`: import, invoice CRUD, bulk delete.

--- a/backend/app/tasks/email.py
+++ b/backend/app/tasks/email.py
@@ -1,4 +1,5 @@
 import logging
+import smtplib
 from datetime import datetime
 from celery import shared_task
 from ..extensions import db
@@ -8,9 +9,9 @@ logger = logging.getLogger(__name__)
 
 
 @shared_task(bind=True, max_retries=2, default_retry_delay=30)
-def enviar_factura_email(self, factura_id: str):
+def enviar_factura_email(self, factura_id: str, tenant_id: str):
     """Envía el comprobante PDF por email al receptor de forma async."""
-    factura = Factura.query.get(factura_id)
+    factura = Factura.query.filter_by(id=factura_id, tenant_id=tenant_id).first()
     if not factura:
         logger.error(f'Factura {factura_id} no encontrada para envío de email')
         return {'error': 'Factura no encontrada'}
@@ -19,16 +20,114 @@ def enviar_factura_email(self, factura_id: str):
         logger.info(f'Factura {factura_id} no autorizada, omitiendo email')
         return {'skipped': True, 'reason': 'No autorizada'}
 
-    # Evitar reenvíos duplicados por retries en cola
-    if factura.email_enviado:
-        logger.info(f'Factura {factura_id} ya tiene email enviado, omitiendo')
+    try:
+        return _enviar_factura_email_sync(factura, allow_resend=False, raise_on_error=True)
+
+    except (
+        smtplib.SMTPException,
+        ConnectionError,
+        ConnectionRefusedError,
+        TimeoutError,
+        OSError,
+        RuntimeError,
+        ValueError,
+    ) as exc:
+        error_data = _normalize_email_error(exc)
+        logger.error(f'Error enviando email para factura {factura_id}: {error_data["message"]}')
+        factura.email_error = error_data['message']
+        db.session.commit()
+
+        # Retry en errores de conexión SMTP
+        if error_data['retryable']:
+            try:
+                self.retry(exc=exc)
+            except self.MaxRetriesExceededError:
+                logger.error(f'Max retries alcanzados para factura {factura_id}')
+                return {
+                    'error': error_data['message'],
+                    'error_code': error_data['code'],
+                    'retries_exhausted': True,
+                }
+
+        return {
+            'error': error_data['message'],
+            'error_code': error_data['code'],
+        }
+
+
+@shared_task(bind=True)
+def enviar_emails_lote(self, lote_id: str, tenant_id: str, mode: str = 'no_enviados'):
+    """Envía emails de un lote completo con progreso y resumen."""
+    if mode not in ['todos', 'no_enviados']:
+        return {'error': 'Modo de envio invalido'}
+
+    query = Factura.query.filter(
+        Factura.tenant_id == tenant_id,
+        Factura.lote_id == lote_id,
+        Factura.estado == 'autorizado',
+    )
+
+    if mode == 'no_enviados':
+        query = query.filter(Factura.email_enviado.is_(False))
+
+    facturas = query.all()
+    total = len(facturas)
+    processed = 0
+    sent = 0
+    skipped = 0
+    errors = 0
+
+    if total == 0:
+        return {
+            'status': 'completed',
+            'processed': 0,
+            'total': 0,
+            'sent': 0,
+            'skipped': 0,
+            'errors': 0,
+        }
+
+    for factura in facturas:
+        result = _enviar_factura_email_sync(
+            factura,
+            allow_resend=(mode == 'todos'),
+            raise_on_error=False,
+        )
+
+        if result.get('success'):
+            sent += 1
+        elif result.get('skipped'):
+            skipped += 1
+        else:
+            errors += 1
+
+        processed += 1
+        self.update_state(state='PROGRESS', meta={
+            'current': processed,
+            'total': total,
+            'percent': int((processed / total) * 100),
+        })
+
+    return {
+        'status': 'completed',
+        'processed': processed,
+        'total': total,
+        'sent': sent,
+        'skipped': skipped,
+        'errors': errors,
+        'mode': mode,
+    }
+
+
+def _enviar_factura_email_sync(factura, allow_resend=False, raise_on_error=False):
+    if factura.email_enviado and not allow_resend:
+        logger.info(f'Factura {factura.id} ya tiene email enviado, omitiendo')
         return {'skipped': True, 'reason': 'Ya enviado'}
 
     if not factura.receptor or not factura.receptor.email:
-        logger.info(f'Factura {factura_id} sin email de receptor, omitiendo')
+        logger.info(f'Factura {factura.id} sin email de receptor, omitiendo')
         return {'skipped': True, 'reason': 'Sin email de receptor'}
 
-    # Verificar que el tenant tiene email configurado y habilitado
     config = EmailConfig.query.filter_by(
         tenant_id=factura.tenant_id,
         email_habilitado=True,
@@ -47,28 +146,31 @@ def enviar_factura_email(self, factura_id: str):
         factura.email_error = None
         db.session.commit()
 
-        logger.info(f'Email enviado para factura {factura_id} a {factura.receptor.email}')
+        logger.info(f'Email enviado para factura {factura.id} a {factura.receptor.email}')
         return {'success': True, 'email': factura.receptor.email}
-
-    except Exception as e:
-        logger.error(f'Error enviando email para factura {factura_id}: {str(e)}')
-        factura.email_error = str(e)[:500]
+    except (
+        smtplib.SMTPException,
+        ConnectionError,
+        ConnectionRefusedError,
+        TimeoutError,
+        OSError,
+        RuntimeError,
+        ValueError,
+    ) as exc:
+        error_data = _normalize_email_error(exc)
+        logger.error(f'Error enviando email para factura {factura.id}: {error_data["message"]}')
+        factura.email_error = error_data['message']
         db.session.commit()
-
-        # Retry en errores de conexión SMTP
-        if _is_retryable(e):
-            try:
-                self.retry(exc=e)
-            except self.MaxRetriesExceededError:
-                logger.error(f'Max retries alcanzados para factura {factura_id}')
-                return {'error': str(e), 'retries_exhausted': True}
-
-        return {'error': str(e)}
+        if raise_on_error:
+            raise
+        return {
+            'error': error_data['message'],
+            'error_code': error_data['code'],
+        }
 
 
 def _is_retryable(exc):
     """Determina si un error SMTP es retryable."""
-    import smtplib
     # Errores permanentes que NO deben reintentarse
     permanent_types = (
         smtplib.SMTPRecipientsRefused,
@@ -86,3 +188,53 @@ def _is_retryable(exc):
         TimeoutError,
     )
     return isinstance(exc, retryable_types)
+
+
+def _normalize_email_error(exc):
+    if isinstance(exc, smtplib.SMTPAuthenticationError):
+        return {
+            'code': 'smtp_auth_error',
+            'message': 'Error de autenticacion SMTP. Revisa usuario, password y servidor.',
+            'retryable': False,
+        }
+
+    if isinstance(exc, smtplib.SMTPRecipientsRefused):
+        return {
+            'code': 'smtp_recipient_refused',
+            'message': 'El servidor SMTP rechazo el destinatario del email.',
+            'retryable': False,
+        }
+
+    if isinstance(exc, smtplib.SMTPSenderRefused):
+        return {
+            'code': 'smtp_sender_refused',
+            'message': 'El servidor SMTP rechazo el remitente configurado.',
+            'retryable': False,
+        }
+
+    if isinstance(exc, smtplib.SMTPDataError):
+        return {
+            'code': 'smtp_data_error',
+            'message': 'El servidor SMTP rechazo el contenido del mensaje.',
+            'retryable': False,
+        }
+
+    if _is_retryable(exc):
+        return {
+            'code': 'smtp_connection_error',
+            'message': 'No se pudo conectar al servidor SMTP. Reintentando.',
+            'retryable': True,
+        }
+
+    if isinstance(exc, (RuntimeError, ValueError)):
+        return {
+            'code': 'email_service_error',
+            'message': 'Error al preparar o enviar el comprobante por email.',
+            'retryable': False,
+        }
+
+    return {
+        'code': 'email_unknown_error',
+        'message': 'Error inesperado al enviar email.',
+        'retryable': False,
+    }

--- a/backend/tests/test_email.py
+++ b/backend/tests/test_email.py
@@ -218,7 +218,10 @@ class TestEnviarEmailFactura:
         assert resp.status_code == 202
         data = resp.get_json()
         assert 'receptor_email' in data
-        mock_task.delay.assert_called_once_with(str(factura_autorizada.id))
+        mock_task.delay.assert_called_once_with(
+            str(factura_autorizada.id),
+            str(factura_autorizada.tenant_id),
+        )
 
     def test_factura_no_autorizada_falla(self, client, auth_headers, db,
                                          email_config, tenant, facturador, receptor_con_email):

--- a/frontend/src/api/client.js
+++ b/frontend/src/api/client.js
@@ -1,5 +1,5 @@
 import axios from 'axios'
-import { useAuthStore } from '../stores/authStore'
+import { useAuthStore } from '@/stores/authStore'
 
 const API_URL = import.meta.env.VITE_API_URL || ''
 
@@ -134,6 +134,8 @@ export const api = {
     list: (params) => client.get('/lotes', { params }),
     get: (id) => client.get(`/lotes/${id}`),
     facturar: (id, data) => client.post(`/lotes/${id}/facturar`, data),
+    sendEmails: (id, data) => client.post(`/lotes/${id}/enviar-emails`, data),
+    emailPreview: (id) => client.get(`/lotes/${id}/email-preview`),
     delete: (id) => client.delete(`/lotes/${id}`),
   },
 

--- a/frontend/src/pages/facturas/BulkEmailModal.jsx
+++ b/frontend/src/pages/facturas/BulkEmailModal.jsx
@@ -1,0 +1,96 @@
+import { useEffect, useState } from 'react'
+import { useQuery } from '@tanstack/react-query'
+import { Button, Modal, Select } from '@/components/ui'
+import { api } from '@/api/client'
+
+function BulkEmailModal({ isOpen, onClose, lotes, onConfirm, isSubmitting }) {
+  const [loteId, setLoteId] = useState('')
+  const [mode, setMode] = useState('no_enviados')
+
+  useEffect(() => {
+    if (!isOpen) return
+    setMode('no_enviados')
+    setLoteId((prev) => prev || lotes[0]?.id || '')
+  }, [isOpen, lotes])
+
+  const { data: previewData } = useQuery({
+    queryKey: ['lotes', 'email-preview', loteId],
+    queryFn: async () => {
+      const response = await api.lotes.emailPreview(loteId)
+      return response.data
+    },
+    enabled: isOpen && !!loteId,
+  })
+
+  const autorizadosCount = previewData?.autorizados || 0
+  const emailsToSend = mode === 'todos'
+    ? (previewData?.enviar_todos || 0)
+    : (previewData?.enviar_no_enviados || 0)
+
+  const handleConfirm = () => {
+    if (!loteId || isSubmitting) return
+    onConfirm({ loteId, mode })
+  }
+
+  return (
+    <Modal
+      isOpen={isOpen}
+      onClose={onClose}
+      title="Enviar emails del lote"
+      className="max-w-lg"
+      footer={(
+        <>
+          <Button variant="secondary" onClick={onClose} disabled={isSubmitting}>
+            Cancelar
+          </Button>
+          <Button onClick={handleConfirm} disabled={!loteId || isSubmitting || emailsToSend === 0}>
+            {isSubmitting ? 'Iniciando...' : 'Ejecutar envio'}
+          </Button>
+        </>
+      )}
+    >
+      <div className="space-y-4">
+        <p className="text-sm text-text-secondary">
+          Solo se enviaran facturas autorizadas. Se omiten automaticamente receptores sin email.
+        </p>
+
+        <Select
+          label="Lote"
+          value={loteId}
+          onChange={(e) => setLoteId(e.target.value)}
+          disabled={isSubmitting || lotes.length === 0}
+        >
+          <option value="">Seleccionar lote...</option>
+          {lotes.map((lote) => (
+            <option key={lote.id} value={lote.id}>
+              {lote.etiqueta}
+              {lote.facturador ? ` - ${lote.facturador.razon_social}` : ''}
+              {` (${lote.total_facturas} facturas)`}
+            </option>
+          ))}
+        </Select>
+
+        <Select
+          label="Modo de envio"
+          value={mode}
+          onChange={(e) => setMode(e.target.value)}
+          disabled={isSubmitting}
+        >
+          <option value="no_enviados">Enviar solo a no enviados</option>
+          <option value="todos">Enviar a todos (incluye reenvios)</option>
+        </Select>
+
+        <div className="space-y-1 rounded-md border border-border bg-secondary/30 p-3">
+          <p className="text-sm text-text-primary">
+            Comprobantes autorizados del lote: <span className="font-semibold">{autorizadosCount}</span>
+          </p>
+          <p className="text-sm text-text-primary">
+            Emails a enviar con este modo: <span className="font-semibold">{emailsToSend}</span>
+          </p>
+        </div>
+      </div>
+    </Modal>
+  )
+}
+
+export default BulkEmailModal


### PR DESCRIPTION
### Fix: mover envío masivo de emails a 'Ver facturas' y reforzar invariantes de lote.
Se implementa el flujo masivo por modal con preview de autorizados y cantidad a enviar por modo, manteniendo el envío individual por comprobante. Además se corrigen validaciones multi-tenant, manejo de errores, cálculos con Decimal y sincronización de contadores agregados del lote.