### PR TITLE
fix: estabilizar facturacion ARCA en lotes

### DIFF
--- a/backend/tests/test_arca_client.py
+++ b/backend/tests/test_arca_client.py
@@ -1,0 +1,141 @@
+import os
+import pickle
+import time
+import tempfile
+
+from arca_integration.client import ArcaClient
+
+
+class _FakeTicket:
+    def __init__(self, is_expired):
+        self.is_expired = is_expired
+
+
+class TestArcaClientTAFallback:
+    def test_uses_shared_ta_cache_dir_from_env(self, monkeypatch):
+        custom_root = os.path.join(tempfile.gettempdir(), 'arca_cache_test_shared')
+        monkeypatch.setenv('ARCA_TA_CACHE_DIR', custom_root)
+
+        client = ArcaClient(
+            cuit='20123456789',
+            cert=b'cert',
+            key=b'key',
+            ambiente='testing',
+        )
+
+        assert client._ta_path.startswith(custom_root)
+
+    def test_has_valid_local_ta_true_when_not_expired(self):
+        client = ArcaClient(
+            cuit='20123456789',
+            cert=b'cert',
+            key=b'key',
+            ambiente='testing',
+        )
+
+        ta_file = os.path.join(client._ta_path, 'wsfe.pkl')
+        with open(ta_file, 'wb') as f:
+            pickle.dump(_FakeTicket(is_expired=False), f)
+
+        assert client._has_valid_local_ta('wsfe') is True
+
+    def test_has_valid_local_ta_false_when_expired(self):
+        client = ArcaClient(
+            cuit='20123456789',
+            cert=b'cert',
+            key=b'key',
+            ambiente='testing',
+        )
+
+        ta_file = os.path.join(client._ta_path, 'wsfe.pkl')
+        with open(ta_file, 'wb') as f:
+            pickle.dump(_FakeTicket(is_expired=True), f)
+
+        assert client._has_valid_local_ta('wsfe') is False
+
+    def test_wsfe_retries_when_arca_reports_existing_ta(self, monkeypatch):
+        client = ArcaClient(
+            cuit='20123456789',
+            cert=b'cert',
+            key=b'key',
+            ambiente='testing',
+        )
+
+        calls = {'count': 0}
+
+        class _FakeWS:
+            pass
+
+        def _fake_ws(_wsdl, service, enable_logging=False):
+            assert service == 'wsfe'
+            calls['count'] += 1
+            if calls['count'] == 1:
+                raise Exception('El CEE ya posee un TA valido para el acceso al WSN solicitado')
+            return _FakeWS()
+
+        monkeypatch.setattr('arca_integration.client.ArcaWebService', _fake_ws)
+        monkeypatch.setattr(client, '_has_valid_local_ta', lambda _service: True)
+        monkeypatch.setattr(time, 'sleep', lambda _seconds: None)
+
+        ws = client.wsfe
+
+        assert isinstance(ws, _FakeWS)
+        assert calls['count'] == 2
+
+    def test_ws_constancia_applies_same_ta_fallback(self, monkeypatch):
+        client = ArcaClient(
+            cuit='20123456789',
+            cert=b'cert',
+            key=b'key',
+            ambiente='testing',
+        )
+
+        calls = {'count': 0}
+
+        class _FakeWS:
+            pass
+
+        def _fake_ws(_wsdl, service, enable_logging=False):
+            assert service == 'ws_sr_constancia_inscripcion'
+            calls['count'] += 1
+            if calls['count'] == 1:
+                raise Exception('El CEE ya posee un TA valido para el acceso al WSN solicitado')
+            return _FakeWS()
+
+        monkeypatch.setattr('arca_integration.client.ArcaWebService', _fake_ws)
+        monkeypatch.setattr(client, '_has_valid_local_ta', lambda _service: True)
+        monkeypatch.setattr(time, 'sleep', lambda _seconds: None)
+
+        ws = client.ws_constancia
+
+        assert isinstance(ws, _FakeWS)
+        assert calls['count'] == 2
+
+    def test_wsfe_fallback_handles_accented_valido_message(self, monkeypatch):
+        client = ArcaClient(
+            cuit='20123456789',
+            cert=b'cert',
+            key=b'key',
+            ambiente='testing',
+        )
+
+        calls = {'count': 0}
+
+        class _FakeWS:
+            pass
+
+        def _fake_ws(_wsdl, service, enable_logging=False):
+            assert service == 'wsfe'
+            calls['count'] += 1
+            if calls['count'] == 1:
+                raise Exception('El CEE ya posee un TA válido para el acceso al WSN solicitado')
+            return _FakeWS()
+
+        monkeypatch.setattr('arca_integration.client.ArcaWebService', _fake_ws)
+        monkeypatch.setattr(client, '_has_valid_local_ta', lambda _service: True)
+        monkeypatch.setattr(time, 'sleep', lambda _seconds: None)
+
+        ws = client.wsfe
+
+        assert isinstance(ws, _FakeWS)
+        assert calls['count'] == 2

--- a/backend/tests/test_facturacion_task.py
+++ b/backend/tests/test_facturacion_task.py
@@ -2,7 +2,11 @@ from datetime import date
 from decimal import Decimal
 
 from app.models import Factura
-from app.tasks.facturacion import procesar_factura
+from app.tasks.facturacion import (
+    procesar_factura,
+    _is_retryable_sequence_error,
+    _sync_factura_date_with_last_authorized,
+)
 
 
 class _FakeClient:
@@ -21,6 +25,21 @@ class _FakeWSFE:
         return {
             'cae': '12345678901234',
             'cae_vencimiento': '2026-12-31',
+        }
+
+
+class _FakeClientDateSync:
+    def __init__(self, ultimo=123, fecha_cbte='20260220'):
+        self.ultimo = ultimo
+        self.fecha_cbte = fecha_cbte
+
+    def fe_comp_ultimo_autorizado(self, punto_venta, tipo_cbte):
+        return self.ultimo
+
+    def fe_comp_consultar(self, tipo_cbte, punto_venta, numero):
+        return {
+            'encontrado': True,
+            'fecha_cbte': self.fecha_cbte,
         }
 
 
@@ -57,3 +76,69 @@ class TestFacturacionTask:
         assert req['ImpIVA'] == 0.0
         assert req['ImpTotal'] == 10000.0
         assert 'Iva' not in req
+
+    def test_retryable_sequence_error_detects_10016(self):
+        assert _is_retryable_sequence_error({
+            'success': False,
+            'error_code': '10016',
+            'error_message': 'El numero o fecha del comprobante no se corresponde',
+        }) is True
+
+    def test_retryable_sequence_error_detects_message_fragment(self):
+        assert _is_retryable_sequence_error({
+            'success': False,
+            'error_message': 'Consultar metodo FECompUltimoAutorizado para el proximo a autorizar',
+        }) is True
+
+    def test_retryable_sequence_error_ignores_success(self):
+        assert _is_retryable_sequence_error({'success': True}) is False
+
+    def test_sync_factura_date_with_last_authorized_adjusts_older_date(self, db, facturador, receptor):
+        factura = Factura(
+            tenant_id=facturador.tenant_id,
+            facturador_id=facturador.id,
+            receptor_id=receptor.id,
+            tipo_comprobante=1,
+            concepto=1,
+            punto_venta=facturador.punto_venta,
+            fecha_emision=date(2026, 1, 15),
+            importe_neto=Decimal('100.00'),
+            importe_iva=Decimal('21.00'),
+            importe_total=Decimal('121.00'),
+            moneda='PES',
+            cotizacion=Decimal('1'),
+            estado='pendiente',
+        )
+
+        changed = _sync_factura_date_with_last_authorized(
+            _FakeClientDateSync(ultimo=555, fecha_cbte='20260220'),
+            factura,
+        )
+
+        assert changed is True
+        assert factura.fecha_emision == date(2026, 2, 20)
+
+    def test_sync_factura_date_with_last_authorized_keeps_newer_date(self, db, facturador, receptor):
+        factura = Factura(
+            tenant_id=facturador.tenant_id,
+            facturador_id=facturador.id,
+            receptor_id=receptor.id,
+            tipo_comprobante=1,
+            concepto=1,
+            punto_venta=facturador.punto_venta,
+            fecha_emision=date(2026, 3, 1),
+            importe_neto=Decimal('100.00'),
+            importe_iva=Decimal('21.00'),
+            importe_total=Decimal('121.00'),
+            moneda='PES',
+            cotizacion=Decimal('1'),
+            estado='pendiente',
+        )
+
+        changed = _sync_factura_date_with_last_authorized(
+            _FakeClientDateSync(ultimo=555, fecha_cbte='20260220'),
+            factura,
+        )
+
+        assert changed is False
+        assert factura.fecha_emision == date(2026, 3, 1)

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -18,11 +18,13 @@ services:
     volumes:
       - ./backend:/app
       - ./arca_integration:/app/arca_integration
+      - facturador_arca_ta_cache:/var/lib/arca_ta_cache
 
   worker:
     volumes:
       - ./backend:/app
       - ./arca_integration:/app/arca_integration
+      - facturador_arca_ta_cache:/var/lib/arca_ta_cache
 
   frontend:
     build:
@@ -39,3 +41,6 @@ services:
       - api
     networks:
       - internal
+
+volumes:
+  facturador_arca_ta_cache:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -41,6 +41,7 @@ services:
       - JWT_SECRET_KEY=${JWT_SECRET_KEY:-jwt-secret-key-change-in-production}
       - ENCRYPTION_KEY=${ENCRYPTION_KEY:-32-caracteres-exactos-para-fern}
       - ARCA_AMBIENTE=${ARCA_AMBIENTE:-testing}
+      - ARCA_TA_CACHE_DIR=/var/lib/arca_ta_cache
       - CORS_ORIGINS=${CORS_ORIGINS:-http://localhost:5173}
     depends_on:
       postgres:
@@ -49,6 +50,8 @@ services:
         condition: service_healthy
     networks:
       - internal
+    volumes:
+      - facturador_arca_ta_cache:/var/lib/arca_ta_cache
 
   worker:
     build:
@@ -63,6 +66,7 @@ services:
       - SECRET_KEY=${SECRET_KEY:-dev-secret-key-change-in-production}
       - ENCRYPTION_KEY=${ENCRYPTION_KEY:-32-caracteres-exactos-para-fern}
       - ARCA_AMBIENTE=${ARCA_AMBIENTE:-testing}
+      - ARCA_TA_CACHE_DIR=/var/lib/arca_ta_cache
     depends_on:
       postgres:
         condition: service_healthy
@@ -70,9 +74,12 @@ services:
         condition: service_healthy
     networks:
       - internal
+    volumes:
+      - facturador_arca_ta_cache:/var/lib/arca_ta_cache
 
 volumes:
   facturador_postgres_data:
+  facturador_arca_ta_cache:
 
 networks:
   internal:


### PR DESCRIPTION
## Summary
- estabiliza facturacion por lote manteniendo el flujo por factura (`FECompUltimoAutorizado -> FECAESolicitar`) con orden determinístico, lock por facturador y retry para errores de secuencia `10016`
- agrega sincronización de fecha de emisión con el último comprobante autorizado antes del retry cuando ARCA rechaza por desfasaje de número/fecha
- implementa fallback de TA para `wsfe` y `ws_constancia`, con cache compartida entre `api`/`worker` vía volumen y `ARCA_TA_CACHE_DIR`
- corrige regresión de `ArcaClient` y suma cobertura en tests para fallback de TA y ajuste de fecha de secuencia

## Testing
- make test-backend
- docker compose -f docker-compose.yml -f docker-compose.dev.yml exec -T api sh -lc "python -m pip show pytest >/dev/null 2>&1 || python -m pip install pytest; cd /app && python -m pytest tests/test_arca_client.py tests/test_facturacion_task.py -q"