### PR TITLE
fix: ajustar modal de importacion, paginacion y alta de receptor

### DIFF
--- a/arca_integration/client.py
+++ b/arca_integration/client.py
@@ -356,14 +356,17 @@ class ArcaClient:
             self._ensure_settings()
             ws = self.ws_constancia
 
-            data = {
-                'token': ws.token,
-                'sign': ws.sign,
-                'cuitRepresentada': ws.cuit,
-                'idPersona': int(cuit_consulta.replace('-', '')),
-            }
-
-            result = ws.send_request('getPersona_v2', data)
+            cuit_int = int(cuit_consulta.replace('-', ''))
+            if hasattr(ws, 'get_persona'):
+                result = ws.get_persona(cuit_int)
+            else:
+                data = {
+                    'token': ws.token,
+                    'sign': ws.sign,
+                    'cuitRepresentada': ws.cuit,
+                    'idPersona': cuit_int,
+                }
+                result = ws.send_request('getPersona_v2', data)
 
             if hasattr(result, 'personaReturn') and result.personaReturn:
                 persona = result.personaReturn

--- a/backend/app/api/receptores.py
+++ b/backend/app/api/receptores.py
@@ -302,9 +302,15 @@ def consultar_cuit():
 
         result = client.consultar_padron(cuit)
 
+        if not result.get('success'):
+            return jsonify({
+                'success': False,
+                'error': result.get('error') or 'No se encontraron datos para el CUIT consultado'
+            }), 404
+
         return jsonify({
             'success': True,
-            'data': result
+            'data': result.get('data', {})
         }), 200
 
     except Exception as e:

--- a/frontend/src/components/ui/Modal.jsx
+++ b/frontend/src/components/ui/Modal.jsx
@@ -1,4 +1,5 @@
 import { useEffect } from 'react'
+import { createPortal } from 'react-dom'
 import { X } from 'lucide-react'
 import { cn } from '@/lib/utils'
 
@@ -16,7 +17,7 @@ function Modal({ isOpen, onClose, title, children, className, footer }) {
 
   if (!isOpen) return null
 
-  return (
+  const modalContent = (
     <div className="fixed inset-0 z-50 flex items-center justify-center">
       {/* Backdrop */}
       <div
@@ -54,6 +55,8 @@ function Modal({ isOpen, onClose, title, children, className, footer }) {
       </div>
     </div>
   )
+
+  return createPortal(modalContent, document.body)
 }
 
 export default Modal

--- a/frontend/src/pages/facturar/ImportModal.jsx
+++ b/frontend/src/pages/facturar/ImportModal.jsx
@@ -12,6 +12,7 @@ function ImportModal({ isOpen, onClose, onSuccess }) {
   const [etiqueta, setEtiqueta] = useState('')
   const [errors, setErrors] = useState([])
   const [isTemplateOpen, setIsTemplateOpen] = useState(false)
+  const [isFormatoOpen, setIsFormatoOpen] = useState(false)
 
   const importMutation = useMutation({
     mutationFn: async () => {
@@ -46,6 +47,7 @@ function ImportModal({ isOpen, onClose, onSuccess }) {
     setEtiqueta('')
     setErrors([])
     setIsTemplateOpen(false)
+    setIsFormatoOpen(false)
     onClose()
   }
 
@@ -148,22 +150,31 @@ function ImportModal({ isOpen, onClose, onSuccess }) {
 
         {/* Step 2: Format info */}
         <div>
-          <h3 className="mb-3 text-sm font-medium text-text-primary">
-            2. Formato esperado
-          </h3>
-          <div className="rounded-md bg-secondary/50 p-3 text-xs text-text-secondary">
-            <p className="mb-2">
-              Podés completar el template .xlsx y luego exportarlo como CSV (UTF-8) para importarlo.
-            </p>
-            <p className="mb-2">Columnas requeridas:</p>
-            <code className="block text-text-muted">
-              facturador_cuit, receptor_cuit, tipo_comprobante, concepto,
-              fecha_emision, importe_total, importe_neto
-            </code>
-            <p className="mt-2">
-              La condición IVA del receptor se determina automáticamente desde el receptor/padrón.
-            </p>
-          </div>
+          <button
+            type="button"
+            onClick={() => setIsFormatoOpen((prev) => !prev)}
+            className="flex w-full items-center justify-between rounded-md border border-border bg-card px-3 py-2 text-left text-sm font-medium text-text-primary hover:bg-secondary/50"
+          >
+            <span>2. Formato esperado</span>
+            <ChevronDown
+              className={`h-4 w-4 text-text-secondary transition-transform ${isFormatoOpen ? 'rotate-180' : ''}`}
+            />
+          </button>
+          {isFormatoOpen && (
+            <div className="mt-3 rounded-md bg-secondary/50 p-3 text-xs text-text-secondary">
+              <p className="mb-2">
+                Podés completar el template .xlsx y luego exportarlo como CSV (UTF-8) para importarlo.
+              </p>
+              <p className="mb-2">Columnas requeridas:</p>
+              <code className="block text-text-muted">
+                facturador_cuit, receptor_cuit, tipo_comprobante, concepto,
+                fecha_emision, importe_total, importe_neto
+              </code>
+              <p className="mt-2">
+                La condición IVA del receptor se determina automáticamente desde el receptor/padrón.
+              </p>
+            </div>
+          )}
         </div>
 
         {/* Step 3: Label */}

--- a/frontend/src/pages/facturas/index.jsx
+++ b/frontend/src/pages/facturas/index.jsx
@@ -180,6 +180,34 @@ function Facturas() {
     !!filters.fecha_hasta,
   ].filter(Boolean).length
 
+  const hasPagination = (data?.total || 0) > 0
+
+  const renderPagination = (position) => (
+    <div className={`flex items-center justify-between px-4 py-3 ${position === 'top' ? 'border-b border-border' : 'border-t border-border'}`}>
+      <span className="text-sm text-text-secondary">
+        Página {data?.page || filters.page} de {data?.pages || 1} · Mostrando {facturas.length} de {data?.total || 0} facturas
+      </span>
+      <div className="flex gap-2">
+        <Button
+          variant="secondary"
+          size="sm"
+          disabled={(data?.page || filters.page) <= 1}
+          onClick={() => setFilters({ ...filters, page: filters.page - 1 })}
+        >
+          Anterior
+        </Button>
+        <Button
+          variant="secondary"
+          size="sm"
+          disabled={(data?.page || filters.page) >= (data?.pages || 1)}
+          onClick={() => setFilters({ ...filters, page: filters.page + 1 })}
+        >
+          Siguiente
+        </Button>
+      </div>
+    </div>
+  )
+
   const getEstadoBadge = (estado, factura) => {
     if (estado === 'error') {
       return (
@@ -330,6 +358,8 @@ function Facturas() {
 
       {/* Table */}
       <div className="rounded-lg border border-border bg-card">
+        {hasPagination && renderPagination('top')}
+
         <Table>
           <TableHeader>
             <TableRow>
@@ -462,32 +492,7 @@ function Facturas() {
           </TableBody>
         </Table>
 
-        {/* Pagination */}
-        {(data?.total || 0) > 0 && (
-          <div className="flex items-center justify-between border-t border-border px-4 py-3">
-            <span className="text-sm text-text-secondary">
-              Página {data?.page || filters.page} de {data?.pages || 1} · Mostrando {facturas.length} de {data.total} facturas
-            </span>
-            <div className="flex gap-2">
-              <Button
-                variant="secondary"
-                size="sm"
-                disabled={(data?.page || filters.page) <= 1}
-                onClick={() => setFilters({ ...filters, page: filters.page - 1 })}
-              >
-                Anterior
-              </Button>
-              <Button
-                variant="secondary"
-                size="sm"
-                disabled={(data?.page || filters.page) >= (data?.pages || 1)}
-                onClick={() => setFilters({ ...filters, page: filters.page + 1 })}
-              >
-                Siguiente
-              </Button>
-            </div>
-          </div>
-        )}
+        {hasPagination && renderPagination('bottom')}
       </div>
 
       <BulkEmailModal

--- a/frontend/src/pages/receptores/index.jsx
+++ b/frontend/src/pages/receptores/index.jsx
@@ -127,21 +127,27 @@ function Receptores() {
   }
 
   const handleConsultarCuit = async () => {
-    if (!formData.doc_nro) return
+    if (!formData.doc_nro) {
+      toast.warning('CUIT requerido', 'Ingresá un CUIT/CUIL para consultar en ARCA')
+      return
+    }
 
     try {
       const response = await api.receptores.consultarCuit(formData.doc_nro)
       if (response.data.success && response.data.data) {
-        const data = response.data.data
-        setFormData({
-          ...formData,
-          razon_social: data.razon_social || formData.razon_social,
-          direccion: data.direccion || formData.direccion,
-          condicion_iva: data.condicion_iva || formData.condicion_iva,
-        })
+        const padronData = response.data.data
+        setFormData((prev) => ({
+          ...prev,
+          razon_social: padronData.razon_social || prev.razon_social,
+          direccion: padronData.direccion || prev.direccion,
+          condicion_iva: padronData.condicion_iva || prev.condicion_iva,
+        }))
+        toast.success('Datos encontrados', 'Se completaron los datos del receptor desde ARCA')
+      } else {
+        toast.warning('Sin resultados', response.data.error || 'No se encontraron datos para ese CUIT')
       }
     } catch (error) {
-      console.error('Error al consultar CUIT:', error)
+      toast.error('Error al consultar CUIT', error.response?.data?.error || 'No se pudo consultar en ARCA')
     }
   }
 
@@ -322,17 +328,19 @@ function Receptores() {
         }
       >
         <div className="space-y-4">
-          <div className="flex items-end gap-3">
-            <Input
-              label="CUIT/CUIL"
-              placeholder="20-12345678-9"
-              value={formData.doc_nro}
-              onChange={(e) => setFormData({ ...formData, doc_nro: e.target.value })}
-              className="flex-1"
-            />
-            <Button variant="secondary" onClick={handleConsultarCuit}>
-              Buscar
-            </Button>
+          <div>
+            <label className="mb-1.5 block text-sm font-medium text-text-primary">CUIT/CUIL</label>
+            <div className="grid grid-cols-[minmax(0,1fr)_auto] items-center gap-2">
+              <Input
+                placeholder="20-12345678-9"
+                value={formData.doc_nro}
+                onChange={(e) => setFormData({ ...formData, doc_nro: e.target.value })}
+                className="w-full"
+              />
+              <Button variant="secondary" className="h-10 shrink-0 px-5" onClick={handleConsultarCuit}>
+                Buscar
+              </Button>
+            </div>
           </div>
 
           <Input


### PR DESCRIPTION
## Summary
- convierte `2. Formato esperado` del modal de Importar Facturas en acordeón colapsable, alineado al patrón de `Descargar template`
- agrega paginación superior en `Ver Facturas` (manteniendo la inferior) para navegar sin ir al final de la tabla
- corrige render de modales vía portal (`document.body`) para evitar artefactos visuales de stacking/recorte
- mejora flujo de `Buscar` en Nuevo Receptor: endpoint devuelve payload plano, frontend autocompleta razón social/dirección/condición IVA y muestra feedback con toasts
- ajusta el layout del campo CUIT/CUIL + botón Buscar en el modal de Nuevo Receptor

## Testing
- make test-backend
- make lint-frontend
- make build-frontend