### PR TITLE
feat: agregar seccion de ayuda con guia y cheatsheet

### DIFF
--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -29,6 +29,7 @@ def create_app(config_class=Config):
     from .api.audit import audit_bp
     from .api.email import email_bp
     from .api.downloads import downloads_bp
+    from .api.help import help_bp
 
     app.register_blueprint(auth_bp, url_prefix='/api/auth')
     app.register_blueprint(dashboard_bp, url_prefix='/api/dashboard')
@@ -42,5 +43,6 @@ def create_app(config_class=Config):
     app.register_blueprint(audit_bp, url_prefix='/api/audit')
     app.register_blueprint(email_bp, url_prefix='/api/email')
     app.register_blueprint(downloads_bp, url_prefix='/api/downloads')
+    app.register_blueprint(help_bp, url_prefix='/api/help')
 
     return app

--- a/backend/app/api/help.py
+++ b/backend/app/api/help.py
@@ -1,0 +1,25 @@
+from pathlib import Path
+
+from flask import Blueprint, Response, jsonify
+
+from ..utils import permission_required
+
+help_bp = Blueprint('help', __name__)
+
+
+@help_bp.route('/guia-importacion-csv', methods=['GET'])
+@permission_required('dashboard:ver')
+def guia_importacion_csv():
+    """Devuelve la guía HTML de importación CSV para la sección Ayuda."""
+    candidates = [
+        Path('/docs/guia_importacion_csv.html'),
+        Path(__file__).resolve().parents[3] / 'docs' / 'guia_importacion_csv.html',
+        Path(__file__).resolve().parents[2] / 'docs' / 'guia_importacion_csv.html',
+    ]
+    guia_path = next((path for path in candidates if path.exists()), None)
+
+    if not guia_path:
+        return jsonify({'error': 'Guía no encontrada'}), 404
+
+    html = guia_path.read_text(encoding='utf-8')
+    return Response(html, mimetype='text/html; charset=utf-8')

--- a/backend/tests/test_help.py
+++ b/backend/tests/test_help.py
@@ -1,0 +1,17 @@
+class TestHelpGuide:
+    def test_guia_importacion_csv_devuelve_html(self, client, auth_headers):
+        response = client.get('/api/help/guia-importacion-csv', headers=auth_headers)
+
+        assert response.status_code == 200
+        assert response.mimetype == 'text/html'
+        body = response.get_data(as_text=True)
+        assert '<!doctype html>' in body.lower()
+        assert 'Guía simple para importar facturas por CSV' in body
+
+    def test_guia_importacion_csv_permite_viewer(self, client, viewer_headers):
+        response = client.get('/api/help/guia-importacion-csv', headers=viewer_headers)
+        assert response.status_code == 200
+
+    def test_guia_importacion_csv_requiere_auth(self, client):
+        response = client.get('/api/help/guia-importacion-csv')
+        assert response.status_code == 401

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -18,6 +18,7 @@ services:
     volumes:
       - ./backend:/app
       - ./arca_integration:/app/arca_integration
+      - ./docs:/docs:ro
       - facturador_arca_ta_cache:/var/lib/arca_ta_cache
 
   worker:

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -13,6 +13,7 @@ import ConsultarComprobantes from './pages/consultar-comprobantes'
 import Usuarios from './pages/usuarios'
 import Auditoria from './pages/auditoria'
 import Email from './pages/email'
+import Ayuda from './pages/ayuda'
 import ZipDownloadsWatcher from './components/downloads/ZipDownloadsWatcher'
 
 function PrivateRoute({ children }) {
@@ -80,6 +81,9 @@ function App() {
           } />
           <Route path="email" element={
             <ProtectedRoute permission="email:configurar"><Email /></ProtectedRoute>
+          } />
+          <Route path="ayuda" element={
+            <ProtectedRoute permission="dashboard:ver"><Ayuda /></ProtectedRoute>
           } />
         </Route>
       </Routes>

--- a/frontend/src/api/client.js
+++ b/frontend/src/api/client.js
@@ -178,4 +178,9 @@ export const api = {
     testSend: (data) => client.post('/email/test-send', data),
     preview: (data) => client.post('/email/preview', data),
   },
+
+  // Ayuda
+  help: {
+    getImportCsvGuide: () => client.get('/help/guia-importacion-csv', { responseType: 'text' }),
+  },
 }

--- a/frontend/src/components/layout/Header.jsx
+++ b/frontend/src/components/layout/Header.jsx
@@ -12,6 +12,7 @@ const pageTitles = {
   '/consultar-comprobantes': 'Consultar Comprobantes',
   '/usuarios': 'Usuarios',
   '/auditoria': 'Auditoría',
+  '/ayuda': 'Ayuda',
   '/email': 'Configuración de Email',
 }
 

--- a/frontend/src/components/layout/Sidebar.jsx
+++ b/frontend/src/components/layout/Sidebar.jsx
@@ -15,6 +15,7 @@ import {
   ClipboardList,
   KeyRound,
   Mail,
+  LifeBuoy,
 } from 'lucide-react'
 import { cn } from '@/lib/utils'
 import { useSidebarStore } from '@/stores/sidebarStore'
@@ -46,6 +47,7 @@ const navItems = [
     items: [
       { icon: UserCog, label: 'Usuarios', href: '/usuarios', permission: 'usuarios:ver' },
       { icon: ClipboardList, label: 'Auditoría', href: '/auditoria', permission: 'auditoria:ver' },
+      { icon: LifeBuoy, label: 'Ayuda', href: '/ayuda', permission: 'dashboard:ver' },
     ],
   },
 ]

--- a/frontend/src/pages/ayuda/index.jsx
+++ b/frontend/src/pages/ayuda/index.jsx
@@ -1,0 +1,87 @@
+import { ExternalLink } from 'lucide-react'
+import { Button } from '@/components/ui'
+import { api } from '@/api/client'
+import { toast } from '@/stores/toastStore'
+
+const TIPOS_COMPROBANTE = [
+  { id: 1, nombre: 'Factura A' },
+  { id: 2, nombre: 'Nota de Debito A' },
+  { id: 3, nombre: 'Nota de Credito A' },
+  { id: 6, nombre: 'Factura B' },
+  { id: 7, nombre: 'Nota de Debito B' },
+  { id: 8, nombre: 'Nota de Credito B' },
+  { id: 11, nombre: 'Factura C' },
+  { id: 12, nombre: 'Nota de Debito C' },
+  { id: 13, nombre: 'Nota de Credito C' },
+  { id: 51, nombre: 'Factura M' },
+  { id: 52, nombre: 'Nota de Debito M' },
+  { id: 53, nombre: 'Nota de Credito M' },
+]
+
+function Ayuda() {
+  const openGuide = async () => {
+    const popup = window.open('', '_blank')
+    if (!popup) {
+      toast.error('No se pudo abrir la guia', 'Habilita ventanas emergentes e intenta nuevamente')
+      return
+    }
+
+    popup.document.title = 'Cargando guia...'
+    popup.document.body.innerHTML = '<p style="font-family: sans-serif; padding: 16px;">Cargando guia...</p>'
+
+    try {
+      const response = await api.help.getImportCsvGuide()
+      const blob = new Blob([response.data], { type: 'text/html;charset=utf-8' })
+      const blobUrl = URL.createObjectURL(blob)
+      popup.location.replace(blobUrl)
+      setTimeout(() => URL.revokeObjectURL(blobUrl), 60000)
+    } catch (error) {
+      popup.close()
+      toast.error('Error al cargar ayuda', error.response?.data?.error || 'No se pudo cargar la guía')
+    }
+  }
+
+  return (
+    <div className="space-y-6">
+      <div className="rounded-lg border border-border bg-card p-5">
+        <h2 className="text-lg font-semibold text-text-primary">Guia de importacion CSV</h2>
+        <p className="mt-1 text-sm text-text-secondary">
+          Abri la guia completa en otra pestana para seguir el paso a paso.
+        </p>
+        <div className="mt-4 flex flex-wrap items-center gap-3">
+          <Button variant="secondary" icon={ExternalLink} onClick={openGuide}>
+            Abrir guia completa
+          </Button>
+        </div>
+      </div>
+
+      <div className="rounded-lg border border-border bg-card p-5">
+        <h3 className="text-base font-semibold text-text-primary">Cheatsheet rapido: IDs de comprobantes</h3>
+        <p className="mt-1 text-sm text-text-secondary">
+          Usa estos IDs en importacion CSV y filtros para encontrar comprobantes mas rapido.
+        </p>
+
+        <div className="mt-4 overflow-hidden rounded-md border border-border">
+          <table className="w-full text-sm">
+            <thead className="bg-secondary/60 text-left">
+              <tr>
+                <th className="w-24 px-4 py-2 text-text-primary">ID</th>
+                <th className="px-4 py-2 text-text-primary">Tipo de comprobante</th>
+              </tr>
+            </thead>
+            <tbody>
+              {TIPOS_COMPROBANTE.map((tipo) => (
+                <tr key={tipo.id} className="border-t border-border">
+                  <td className="px-4 py-2 font-mono text-text-primary">{tipo.id}</td>
+                  <td className="px-4 py-2 text-text-secondary">{tipo.nombre}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export default Ayuda


### PR DESCRIPTION
## Summary
- agrega nueva pestaña `Ayuda` en sidebar (debajo de Usuarios/Auditoría) disponible para admin, operator y viewer
- incorpora nueva vista `/ayuda` con botón para abrir la guía de importación en nueva pestaña y cheatsheet rápido de IDs de comprobantes
- añade endpoint backend `GET /api/help/guia-importacion-csv` para servir `docs/guia_importacion_csv.html` con auth, y registra el blueprint correspondiente
- corrige acceso a la guía en entorno dev montando `./docs` dentro del contenedor `api`

## Testing
- make test-backend
- make lint-frontend
- make build-frontend