### PR TITLE
feat: ampliar dashboard con filtros por periodo y KPIs

### DIFF
--- a/backend/app/api/dashboard.py
+++ b/backend/app/api/dashboard.py
@@ -1,8 +1,11 @@
-from datetime import datetime, timedelta
-from flask import Blueprint, g, jsonify
+from datetime import datetime, date
+from decimal import Decimal
+
+from flask import Blueprint, g, jsonify, request
 from sqlalchemy import func
+
 from ..extensions import db
-from ..models import Factura
+from ..models import Factura, Receptor
 from ..utils import permission_required
 
 dashboard_bp = Blueprint('dashboard', __name__)
@@ -11,49 +14,209 @@ dashboard_bp = Blueprint('dashboard', __name__)
 @dashboard_bp.route('/stats', methods=['GET'])
 @permission_required('dashboard:ver')
 def get_stats():
-    """Obtener estadísticas del dashboard."""
+    month_param = (request.args.get('month') or '').strip()
+    historico = (request.args.get('historico', 'false') or '').lower() == 'true'
 
-    # Inicio del mes actual
     today = datetime.utcnow().date()
-    first_day_of_month = today.replace(day=1)
+    selected_month = _parse_month(month_param) if month_param else today.replace(day=1)
 
-    # Total de facturas del mes
-    facturas_mes = Factura.query.filter(
-        Factura.tenant_id == g.tenant_id,
-        Factura.fecha_emision >= first_day_of_month
-    ).count()
+    period_start = None if historico else selected_month
+    period_end = None if historico else _next_month(selected_month)
 
-    # Facturas autorizadas
-    facturas_autorizadas = Factura.query.filter(
-        Factura.tenant_id == g.tenant_id,
-        Factura.fecha_emision >= first_day_of_month,
+    base_query = Factura.query.filter(Factura.tenant_id == g.tenant_id)
+    period_query = _apply_period_filter(base_query, period_start, period_end)
+
+    facturas_mes = period_query.count()
+    facturas_autorizadas = period_query.filter(Factura.estado == 'autorizado').count()
+    facturas_error = period_query.filter(Factura.estado == 'error').count()
+    facturas_pendientes = period_query.filter(Factura.estado.in_(['borrador', 'pendiente'])).count()
+
+    total_mes = period_query.with_entities(func.sum(Factura.importe_total)).filter(
         Factura.estado == 'autorizado'
-    ).count()
+    ).scalar() or Decimal('0')
 
-    # Facturas con error
-    facturas_error = Factura.query.filter(
-        Factura.tenant_id == g.tenant_id,
-        Factura.fecha_emision >= first_day_of_month,
-        Factura.estado == 'error'
-    ).count()
-
-    # Facturas pendientes
-    facturas_pendientes = Factura.query.filter(
-        Factura.tenant_id == g.tenant_id,
-        Factura.estado.in_(['borrador', 'pendiente'])
-    ).count()
-
-    # Total facturado del mes
-    total_mes = db.session.query(func.sum(Factura.importe_total)).filter(
-        Factura.tenant_id == g.tenant_id,
-        Factura.fecha_emision >= first_day_of_month,
-        Factura.estado == 'autorizado'
-    ).scalar() or 0
+    ticket_promedio = _build_ticket_promedio(
+        tenant_id=g.tenant_id,
+        period_start=period_start,
+        period_end=period_end,
+        historico=historico,
+    )
 
     return jsonify({
         'facturas_mes': facturas_mes,
         'autorizadas': facturas_autorizadas,
         'errores': facturas_error,
         'pendientes': facturas_pendientes,
-        'total_mes': float(total_mes)
+        'total_mes': float(total_mes),
+        'facturacion_12_meses': _build_facturacion_12_meses(g.tenant_id, selected_month),
+        'top_clientes': _build_top_clientes(g.tenant_id, period_start, period_end),
+        'ticket_promedio': ticket_promedio,
+        'filtros_aplicados': {
+            'historico': historico,
+            'month': selected_month.strftime('%Y-%m'),
+        },
     }), 200
+
+
+def _parse_month(value: str) -> date:
+    try:
+        return datetime.strptime(value, '%Y-%m').date().replace(day=1)
+    except ValueError:
+        return datetime.utcnow().date().replace(day=1)
+
+
+def _next_month(value: date) -> date:
+    if value.month == 12:
+        return date(value.year + 1, 1, 1)
+    return date(value.year, value.month + 1, 1)
+
+
+def _apply_period_filter(query, period_start: date | None, period_end: date | None):
+    if period_start is not None:
+        query = query.filter(Factura.fecha_emision >= period_start)
+    if period_end is not None:
+        query = query.filter(Factura.fecha_emision < period_end)
+    return query
+
+
+def _month_key(year: int, month: int) -> str:
+    return f'{year:04d}-{month:02d}'
+
+
+def _month_label(value: date) -> str:
+    months = ['ene', 'feb', 'mar', 'abr', 'may', 'jun', 'jul', 'ago', 'sep', 'oct', 'nov', 'dic']
+    return f'{months[value.month - 1]} {value.year}'
+
+
+def _sub_months(value: date, count: int) -> date:
+    idx = (value.year * 12 + (value.month - 1)) - count
+    year = idx // 12
+    month = idx % 12 + 1
+    return date(year, month, 1)
+
+
+def _build_facturacion_12_meses(tenant_id, selected_month: date):
+    start_month = _sub_months(selected_month, 11)
+    end_month = _next_month(selected_month)
+
+    rows = db.session.query(
+        func.extract('year', Factura.fecha_emision).label('year'),
+        func.extract('month', Factura.fecha_emision).label('month'),
+        func.count(Factura.id).label('cantidad'),
+        func.coalesce(func.sum(Factura.importe_total), 0).label('total'),
+    ).filter(
+        Factura.tenant_id == tenant_id,
+        Factura.estado == 'autorizado',
+        Factura.fecha_emision >= start_month,
+        Factura.fecha_emision < end_month,
+    ).group_by('year', 'month').all()
+
+    by_month = {
+        _month_key(int(row.year), int(row.month)): {
+            'cantidad': int(row.cantidad or 0),
+            'total': float(row.total or 0),
+        }
+        for row in rows
+    }
+
+    serie = []
+    for idx in range(12):
+        month_date = _sub_months(selected_month, 11 - idx)
+        key = month_date.strftime('%Y-%m')
+        values = by_month.get(key, {'cantidad': 0, 'total': 0.0})
+        serie.append({
+            'month': key,
+            'label': _month_label(month_date),
+            'cantidad': values['cantidad'],
+            'total': values['total'],
+        })
+
+    return serie
+
+
+def _build_top_clientes(tenant_id, period_start: date | None, period_end: date | None):
+    top_query = db.session.query(
+        Factura.receptor_id,
+        Receptor.razon_social,
+        Receptor.doc_nro,
+        func.count(Factura.id).label('cantidad'),
+        func.coalesce(func.sum(Factura.importe_total), 0).label('total'),
+    ).join(
+        Receptor,
+        Receptor.id == Factura.receptor_id,
+    ).filter(
+        Factura.tenant_id == tenant_id,
+        Factura.estado == 'autorizado',
+    )
+
+    top_query = _apply_period_filter(top_query, period_start, period_end)
+
+    rows = top_query.group_by(
+        Factura.receptor_id,
+        Receptor.razon_social,
+        Receptor.doc_nro,
+    ).order_by(
+        func.sum(Factura.importe_total).desc(),
+        func.count(Factura.id).desc(),
+    ).limit(10).all()
+
+    total_periodo = db.session.query(
+        func.coalesce(func.sum(Factura.importe_total), 0)
+    ).filter(
+        Factura.tenant_id == tenant_id,
+        Factura.estado == 'autorizado',
+    )
+    total_periodo = _apply_period_filter(total_periodo, period_start, period_end).scalar() or Decimal('0')
+
+    result = []
+    for row in rows:
+        total_cliente = row.total or Decimal('0')
+        porcentaje = float((total_cliente / total_periodo) * Decimal('100')) if total_periodo > 0 else 0.0
+        result.append({
+            'receptor_id': str(row.receptor_id),
+            'razon_social': row.razon_social,
+            'doc_nro': row.doc_nro,
+            'cantidad': int(row.cantidad or 0),
+            'total': float(total_cliente),
+            'porcentaje': round(porcentaje, 2),
+        })
+
+    return result
+
+
+def _ticket_value(tenant_id, period_start: date | None, period_end: date | None):
+    query = db.session.query(
+        func.coalesce(func.sum(Factura.importe_total), 0).label('total'),
+        func.count(Factura.id).label('cantidad'),
+    ).filter(
+        Factura.tenant_id == tenant_id,
+        Factura.estado == 'autorizado',
+    )
+
+    row = _apply_period_filter(query, period_start, period_end).first()
+    total = row.total or Decimal('0')
+    cantidad = int(row.cantidad or 0)
+    valor = (total / cantidad) if cantidad else Decimal('0')
+    return valor, total, cantidad
+
+
+def _build_ticket_promedio(tenant_id, period_start: date | None, period_end: date | None, historico: bool):
+    actual, actual_total, actual_cantidad = _ticket_value(tenant_id, period_start, period_end)
+    variacion_pct = None
+    anterior_valor = None
+
+    if not historico and period_start is not None:
+        previous_start = _sub_months(period_start, 1)
+        previous_end = period_start
+        anterior, _, _ = _ticket_value(tenant_id, previous_start, previous_end)
+        anterior_valor = float(anterior)
+        if anterior > 0:
+            variacion_pct = float(((actual - anterior) / anterior) * Decimal('100'))
+
+    return {
+        'valor': float(actual),
+        'total': float(actual_total),
+        'cantidad': actual_cantidad,
+        'variacion_pct': round(variacion_pct, 2) if variacion_pct is not None else None,
+        'valor_periodo_anterior': anterior_valor,
+    }

--- a/backend/tests/test_dashboard.py
+++ b/backend/tests/test_dashboard.py
@@ -1,0 +1,159 @@
+from datetime import date
+from decimal import Decimal
+
+from app.models import Factura, Facturador, Receptor, Tenant
+
+
+def _create_factura(db, tenant_id, facturador_id, receptor_id, fecha_emision, importe_total, estado='autorizado'):
+    factura = Factura(
+        tenant_id=tenant_id,
+        facturador_id=facturador_id,
+        receptor_id=receptor_id,
+        tipo_comprobante=1,
+        concepto=1,
+        punto_venta=1,
+        fecha_emision=fecha_emision,
+        importe_total=Decimal(str(importe_total)),
+        importe_neto=Decimal(str(importe_total)),
+        estado=estado,
+    )
+    db.session.add(factura)
+    return factura
+
+
+class TestDashboardStats:
+    def test_dashboard_defaults_to_current_month(self, client, auth_headers, db, tenant, facturador, receptor):
+        today = date.today()
+        current_month_day = today.replace(day=5)
+
+        _create_factura(db, tenant.id, facturador.id, receptor.id, current_month_day, '1000.00', estado='autorizado')
+        _create_factura(db, tenant.id, facturador.id, receptor.id, current_month_day, '1200.00', estado='error')
+
+        previous_month = date(today.year - 1, 12, 10) if today.month == 1 else date(today.year, today.month - 1, 10)
+        _create_factura(db, tenant.id, facturador.id, receptor.id, previous_month, '9999.00', estado='autorizado')
+        db.session.commit()
+
+        response = client.get('/api/dashboard/stats', headers=auth_headers)
+        assert response.status_code == 200
+
+        payload = response.get_json()
+        assert payload['facturas_mes'] == 2
+        assert payload['autorizadas'] == 1
+        assert payload['errores'] == 1
+        assert payload['pendientes'] == 0
+        assert payload['total_mes'] == 1000.0
+        assert payload['filtros_aplicados']['historico'] is False
+        assert len(payload['facturacion_12_meses']) == 12
+
+    def test_dashboard_month_filter_applies_to_all_stats(self, client, auth_headers, db, tenant, facturador, receptor):
+        _create_factura(db, tenant.id, facturador.id, receptor.id, date(2026, 1, 10), '1000.00', estado='autorizado')
+        _create_factura(db, tenant.id, facturador.id, receptor.id, date(2026, 1, 11), '200.00', estado='error')
+        _create_factura(db, tenant.id, facturador.id, receptor.id, date(2026, 1, 12), '150.00', estado='pendiente')
+        _create_factura(db, tenant.id, facturador.id, receptor.id, date(2026, 1, 13), '100.00', estado='borrador')
+
+        _create_factura(db, tenant.id, facturador.id, receptor.id, date(2026, 2, 10), '9999.00', estado='pendiente')
+        db.session.commit()
+
+        response = client.get('/api/dashboard/stats?month=2026-01', headers=auth_headers)
+        assert response.status_code == 200
+
+        payload = response.get_json()
+        assert payload['facturas_mes'] == 4
+        assert payload['autorizadas'] == 1
+        assert payload['errores'] == 1
+        assert payload['pendientes'] == 2
+        assert payload['total_mes'] == 1000.0
+        assert payload['filtros_aplicados']['month'] == '2026-01'
+
+    def test_dashboard_historico_includes_all_months(self, client, auth_headers, db, tenant, facturador, receptor):
+        _create_factura(db, tenant.id, facturador.id, receptor.id, date(2026, 1, 10), '1000.00', estado='autorizado')
+        _create_factura(db, tenant.id, facturador.id, receptor.id, date(2026, 2, 10), '1500.00', estado='autorizado')
+        _create_factura(db, tenant.id, facturador.id, receptor.id, date(2026, 2, 12), '200.00', estado='pendiente')
+        db.session.commit()
+
+        response = client.get('/api/dashboard/stats?historico=true', headers=auth_headers)
+        assert response.status_code == 200
+
+        payload = response.get_json()
+        assert payload['facturas_mes'] == 3
+        assert payload['autorizadas'] == 2
+        assert payload['pendientes'] == 1
+        assert payload['total_mes'] == 2500.0
+        assert payload['filtros_aplicados']['historico'] is True
+        assert payload['ticket_promedio']['variacion_pct'] is None
+
+    def test_dashboard_top_clientes_and_ticket_promedio(self, client, auth_headers, db, tenant, facturador):
+        receptor_a = Receptor(
+            tenant_id=tenant.id,
+            doc_tipo=80,
+            doc_nro='30111222333',
+            razon_social='Cliente A',
+            activo=True,
+        )
+        receptor_b = Receptor(
+            tenant_id=tenant.id,
+            doc_tipo=80,
+            doc_nro='30222444555',
+            razon_social='Cliente B',
+            activo=True,
+        )
+        db.session.add_all([receptor_a, receptor_b])
+        db.session.commit()
+
+        _create_factura(db, tenant.id, facturador.id, receptor_a.id, date(2026, 1, 10), '1200.00', estado='autorizado')
+        _create_factura(db, tenant.id, facturador.id, receptor_a.id, date(2026, 1, 12), '800.00', estado='autorizado')
+        _create_factura(db, tenant.id, facturador.id, receptor_b.id, date(2026, 1, 15), '500.00', estado='autorizado')
+
+        _create_factura(db, tenant.id, facturador.id, receptor_a.id, date(2025, 12, 10), '500.00', estado='autorizado')
+        _create_factura(db, tenant.id, facturador.id, receptor_b.id, date(2025, 12, 11), '500.00', estado='autorizado')
+        db.session.commit()
+
+        response = client.get('/api/dashboard/stats?month=2026-01', headers=auth_headers)
+        assert response.status_code == 200
+
+        payload = response.get_json()
+
+        assert payload['ticket_promedio']['valor'] == 833.3333333333334
+        assert payload['ticket_promedio']['valor_periodo_anterior'] == 500.0
+        assert payload['ticket_promedio']['variacion_pct'] == 66.67
+
+        top_clientes = payload['top_clientes']
+        assert len(top_clientes) == 2
+        assert top_clientes[0]['razon_social'] == 'Cliente A'
+        assert top_clientes[0]['total'] == 2000.0
+        assert top_clientes[0]['porcentaje'] == 80.0
+
+    def test_dashboard_is_tenant_isolated(self, client, auth_headers, db, tenant, facturador, receptor):
+        other_tenant = Tenant(nombre='Otro tenant', slug='otro-tenant', activo=True)
+        db.session.add(other_tenant)
+        db.session.flush()
+
+        other_facturador = Facturador(
+            tenant_id=other_tenant.id,
+            cuit='20999888776',
+            razon_social='Otro Facturador',
+            punto_venta=1,
+            condicion_iva='IVA Responsable Inscripto',
+            ambiente='testing',
+            activo=True,
+        )
+        other_receptor = Receptor(
+            tenant_id=other_tenant.id,
+            doc_tipo=80,
+            doc_nro='30999000111',
+            razon_social='Otro Cliente',
+            activo=True,
+        )
+        db.session.add_all([other_facturador, other_receptor])
+        db.session.flush()
+
+        _create_factura(db, tenant.id, facturador.id, receptor.id, date(2026, 1, 10), '1000.00', estado='autorizado')
+        _create_factura(db, other_tenant.id, other_facturador.id, other_receptor.id, date(2026, 1, 11), '9000.00', estado='autorizado')
+        db.session.commit()
+
+        response = client.get('/api/dashboard/stats?month=2026-01', headers=auth_headers)
+        assert response.status_code == 200
+
+        payload = response.get_json()
+        assert payload['facturas_mes'] == 1
+        assert payload['total_mes'] == 1000.0

--- a/frontend/src/api/client.js
+++ b/frontend/src/api/client.js
@@ -77,7 +77,7 @@ export const api = {
 
   // Dashboard
   dashboard: {
-    getStats: () => client.get('/dashboard/stats'),
+    getStats: (params) => client.get('/dashboard/stats', { params }),
   },
 
   // Facturadores

--- a/frontend/src/pages/Dashboard.jsx
+++ b/frontend/src/pages/Dashboard.jsx
@@ -1,17 +1,61 @@
+import { useState } from 'react'
 import { useQuery } from '@tanstack/react-query'
-import { FileText, CheckCircle, XCircle, Clock } from 'lucide-react'
+import { FileText, CheckCircle, XCircle, Clock, TrendingUp, Users } from 'lucide-react'
 import { api } from '@/api/client'
-import { MetricCard } from '@/components/ui'
+import {
+  Button,
+  Input,
+  MetricCard,
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui'
 import { formatCurrency } from '@/lib/utils'
 
+function formatMonthOption(value) {
+  const [year, month] = value.split('-').map(Number)
+  const labels = ['enero', 'febrero', 'marzo', 'abril', 'mayo', 'junio', 'julio', 'agosto', 'septiembre', 'octubre', 'noviembre', 'diciembre']
+  return `${labels[(month || 1) - 1]} ${year}`
+}
+
+function getCurrentMonthValue() {
+  const now = new Date()
+  const month = String(now.getMonth() + 1).padStart(2, '0')
+  return `${now.getFullYear()}-${month}`
+}
+
 function Dashboard() {
+  const [selectedMonth, setSelectedMonth] = useState(getCurrentMonthValue())
+  const [historico, setHistorico] = useState(false)
+
   const { data: stats, isLoading } = useQuery({
-    queryKey: ['dashboard-stats'],
+    queryKey: ['dashboard-stats', { selectedMonth, historico }],
     queryFn: async () => {
-      const response = await api.dashboard.getStats()
+      const params = historico
+        ? { historico: true }
+        : { month: selectedMonth }
+      const response = await api.dashboard.getStats(params)
       return response.data
     },
   })
+
+  const trendData = stats?.facturacion_12_meses || []
+  const topClientes = stats?.top_clientes || []
+  const ticket = stats?.ticket_promedio || null
+  const maxTrendTotal = trendData.reduce((max, item) => Math.max(max, item.total || 0), 0)
+
+  const periodoLabel = historico
+    ? 'Historico'
+    : formatMonthOption(stats?.filtros_aplicados?.month || selectedMonth)
+
+  const ticketVariation = ticket?.variacion_pct
+  const ticketVariationLabel =
+    ticketVariation == null
+      ? 'Sin comparacion'
+      : `${ticketVariation > 0 ? '+' : ''}${ticketVariation.toFixed(2)}% vs mes anterior`
 
   if (isLoading) {
     return (
@@ -23,14 +67,49 @@ function Dashboard() {
 
   return (
     <div className="space-y-6">
+      <div className="rounded-lg bg-card p-6 shadow-sm">
+        <div className="flex flex-wrap items-end justify-between gap-4">
+          <div>
+            <h2 className="mb-2 text-lg font-semibold text-text-primary">
+              {historico ? 'Total Facturado del Periodo' : 'Total Facturado del Mes'}
+            </h2>
+            <p className="text-4xl font-bold text-primary">
+              {formatCurrency(stats?.total_mes || 0)}
+            </p>
+          </div>
+
+          <div className="flex flex-wrap items-end gap-2">
+            <div className="w-full sm:w-auto sm:min-w-[220px]">
+              <Input
+                type="month"
+                label="Mes de analisis"
+                value={selectedMonth}
+                disabled={historico}
+                max={getCurrentMonthValue()}
+                onChange={(event) => setSelectedMonth(event.target.value)}
+              />
+            </div>
+            <Button
+              variant={historico ? 'primary' : 'secondary'}
+              onClick={() => setHistorico((prev) => !prev)}
+            >
+              Historico
+            </Button>
+          </div>
+        </div>
+        <p className="mt-3 text-sm text-text-secondary">
+          Periodo seleccionado: <span className="font-medium text-text-primary">{periodoLabel}</span>
+        </p>
+      </div>
+
       {/* Metrics Grid */}
       <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-4">
         <MetricCard
-          label="Facturas del Mes"
+          label={historico ? 'Facturas del Periodo' : 'Facturas del Mes'}
           value={stats?.facturas_mes || 0}
         />
         <MetricCard
-          label="Autorizadas"
+          label={historico ? 'Autorizadas (Periodo)' : 'Autorizadas'}
           value={stats?.autorizadas || 0}
         />
         <MetricCard
@@ -43,14 +122,87 @@ function Dashboard() {
         />
       </div>
 
-      {/* Total Facturado */}
+      <div className="grid gap-6 lg:grid-cols-2">
+        <div className="rounded-lg bg-card p-6 shadow-sm">
+          <div className="mb-4 flex items-center justify-between">
+            <h2 className="text-lg font-semibold text-text-primary">Facturacion mensual (12 meses)</h2>
+            <TrendingUp className="h-5 w-5 text-primary" />
+          </div>
+
+          <div className="space-y-3">
+            {trendData.map((item) => {
+              const widthPercent = maxTrendTotal > 0 ? ((item.total || 0) / maxTrendTotal) * 100 : 0
+              return (
+                <div key={item.month}>
+                  <div className="mb-1 flex items-center justify-between gap-2 text-sm">
+                    <span className="text-text-secondary">{item.label}</span>
+                    <span className="font-medium text-text-primary">
+                      {formatCurrency(item.total || 0)} - {item.cantidad || 0} facturas
+                    </span>
+                  </div>
+                  <div className="h-2 rounded-full bg-secondary">
+                    <div
+                      className="h-2 rounded-full bg-primary transition-all"
+                      style={{ width: `${Math.max(widthPercent, 2)}%` }}
+                    />
+                  </div>
+                </div>
+              )
+            })}
+          </div>
+        </div>
+
+        <div className="rounded-lg bg-card p-6 shadow-sm">
+          <div className="mb-2 flex items-center justify-between">
+            <h2 className="text-lg font-semibold text-text-primary">Ticket promedio</h2>
+            <FileText className="h-5 w-5 text-primary" />
+          </div>
+          <p className="text-4xl font-bold text-primary">
+            {formatCurrency(ticket?.valor || 0)}
+          </p>
+          <p className="mt-2 text-sm text-text-secondary">
+            Total facturado: <span className="font-medium text-text-primary">{formatCurrency(ticket?.total || 0)}</span>
+            {' '}en <span className="font-medium text-text-primary">{ticket?.cantidad || 0}</span> facturas autorizadas
+          </p>
+          <p className={`mt-2 text-sm ${ticketVariation != null && ticketVariation >= 0 ? 'text-success' : 'text-text-secondary'}`}>
+            {ticketVariationLabel}
+          </p>
+        </div>
+      </div>
+
       <div className="rounded-lg bg-card p-6 shadow-sm">
-        <h2 className="mb-2 text-lg font-semibold text-text-primary">
-          Total Facturado del Mes
-        </h2>
-        <p className="text-4xl font-bold text-primary">
-          {formatCurrency(stats?.total_mes || 0)}
-        </p>
+        <div className="mb-4 flex items-center justify-between">
+          <h2 className="text-lg font-semibold text-text-primary">Top 10 clientes por facturacion</h2>
+          <Users className="h-5 w-5 text-primary" />
+        </div>
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>Cliente</TableHead>
+              <TableHead>Documento</TableHead>
+              <TableHead>Cantidad</TableHead>
+              <TableHead>Total</TableHead>
+              <TableHead>% participacion</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {topClientes.length === 0 ? (
+              <TableRow>
+                <TableCell colSpan={5} className="text-center text-text-muted">No hay datos para el periodo seleccionado</TableCell>
+              </TableRow>
+            ) : (
+              topClientes.map((cliente) => (
+                <TableRow key={cliente.receptor_id}>
+                  <TableCell className="font-medium">{cliente.razon_social}</TableCell>
+                  <TableCell>{cliente.doc_nro}</TableCell>
+                  <TableCell>{cliente.cantidad}</TableCell>
+                  <TableCell>{formatCurrency(cliente.total || 0)}</TableCell>
+                  <TableCell>{cliente.porcentaje?.toFixed?.(2) || '0.00'}%</TableCell>
+                </TableRow>
+              ))
+            )}
+          </TableBody>
+        </Table>
       </div>
 
       {/* Quick Actions */}


### PR DESCRIPTION
## Summary
- corrige los KPIs del dashboard para usar filtros temporales consistentes por mes seleccionado o modo historico
- agrega nuevos reportes de negocio: facturacion mensual de 12 meses, top 10 clientes por facturacion y ticket promedio con variacion
- actualiza la UI del dashboard con selector mensual tipo datepicker, boton Historico y nueva distribucion de bloques

## Testing
- make test-backend
- make lint-frontend
- make build-frontend