### PR TITLE
feat: restringir dashboard sensible por usuario

### DIFF
--- a/backend/app/models/usuario.py
+++ b/backend/app/models/usuario.py
@@ -13,6 +13,7 @@ class Usuario(db.Model):
     password_hash = db.Column(db.String(255), nullable=False)
     nombre = db.Column(db.String(255))
     rol = db.Column(db.String(50), default='operator')
+    restringir_dashboard_sensible = db.Column(db.Boolean, default=False)
     activo = db.Column(db.Boolean, default=True)
     ultimo_login = db.Column(db.DateTime)
     created_at = db.Column(db.DateTime, default=datetime.utcnow)
@@ -40,6 +41,7 @@ class Usuario(db.Model):
             'email': self.email,
             'nombre': self.nombre,
             'rol': self.rol,
+            'restringir_dashboard_sensible': self.restringir_dashboard_sensible,
             'activo': self.activo,
             'ultimo_login': self.ultimo_login.isoformat() if self.ultimo_login else None,
             'created_at': self.created_at.isoformat()

--- a/backend/migrations/versions/9c1a4d8e72b3_add_dashboard_visibility_restriction_to_usuario.py
+++ b/backend/migrations/versions/9c1a4d8e72b3_add_dashboard_visibility_restriction_to_usuario.py
@@ -1,0 +1,29 @@
+"""add dashboard visibility restriction to usuario
+
+Revision ID: 9c1a4d8e72b3
+Revises: 6f2c9c2b1c41
+Create Date: 2026-02-28 14:10:00.000000
+"""
+
+from alembic import op
+import sqlalchemy as sa
+from migrations.helpers import column_exists
+
+
+revision = '9c1a4d8e72b3'
+down_revision = '6f2c9c2b1c41'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    if not column_exists('usuario', 'restringir_dashboard_sensible'):
+        op.add_column(
+            'usuario',
+            sa.Column('restringir_dashboard_sensible', sa.Boolean(), nullable=False, server_default=sa.false()),
+        )
+
+
+def downgrade():
+    if column_exists('usuario', 'restringir_dashboard_sensible'):
+        op.drop_column('usuario', 'restringir_dashboard_sensible')

--- a/frontend/src/hooks/useAuth.js
+++ b/frontend/src/hooks/useAuth.js
@@ -1,15 +1,17 @@
-import { useMutation, useQuery } from '@tanstack/react-query'
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { useNavigate } from 'react-router-dom'
 import { api } from '../api/client'
 import { useAuthStore } from '../stores/authStore'
 
 export function useLogin() {
   const navigate = useNavigate()
+  const queryClient = useQueryClient()
   const setAuth = useAuthStore((state) => state.setAuth)
 
   return useMutation({
     mutationFn: (credentials) => api.auth.login(credentials),
     onSuccess: (response) => {
+      queryClient.clear()
       setAuth(response.data)
       navigate('/dashboard')
     },
@@ -18,16 +20,19 @@ export function useLogin() {
 
 export function useLogout() {
   const navigate = useNavigate()
+  const queryClient = useQueryClient()
   const logout = useAuthStore((state) => state.logout)
 
   return useMutation({
     mutationFn: () => api.auth.logout(),
     onSuccess: () => {
+      queryClient.clear()
       logout()
       navigate('/login')
     },
     onError: () => {
       // Even if the API call fails, logout locally
+      queryClient.clear()
       logout()
       navigate('/login')
     },

--- a/frontend/src/pages/Dashboard.jsx
+++ b/frontend/src/pages/Dashboard.jsx
@@ -2,6 +2,7 @@ import { useState } from 'react'
 import { useQuery } from '@tanstack/react-query'
 import { FileText, CheckCircle, XCircle, Clock, TrendingUp, Users } from 'lucide-react'
 import { api } from '@/api/client'
+import { useAuthStore } from '@/stores/authStore'
 import {
   Button,
   Input,
@@ -28,11 +29,12 @@ function getCurrentMonthValue() {
 }
 
 function Dashboard() {
+  const currentUserId = useAuthStore((s) => s.user?.id)
   const [selectedMonth, setSelectedMonth] = useState(getCurrentMonthValue())
   const [historico, setHistorico] = useState(false)
 
   const { data: stats, isLoading } = useQuery({
-    queryKey: ['dashboard-stats', { selectedMonth, historico }],
+    queryKey: ['dashboard-stats', currentUserId, { selectedMonth, historico }],
     queryFn: async () => {
       const params = historico
         ? { historico: true }
@@ -40,11 +42,13 @@ function Dashboard() {
       const response = await api.dashboard.getStats(params)
       return response.data
     },
+    enabled: !!currentUserId,
   })
 
   const trendData = stats?.facturacion_12_meses || []
   const topClientes = stats?.top_clientes || []
   const ticket = stats?.ticket_promedio || null
+  const sensitiveHidden = !!stats?.sensitive_hidden
   const maxTrendTotal = trendData.reduce((max, item) => Math.max(max, item.total || 0), 0)
 
   const periodoLabel = historico
@@ -67,40 +71,48 @@ function Dashboard() {
 
   return (
     <div className="space-y-6">
-      <div className="rounded-lg bg-card p-6 shadow-sm">
-        <div className="flex flex-wrap items-end justify-between gap-4">
-          <div>
-            <h2 className="mb-2 text-lg font-semibold text-text-primary">
-              {historico ? 'Total Facturado del Periodo' : 'Total Facturado del Mes'}
-            </h2>
-            <p className="text-4xl font-bold text-primary">
-              {formatCurrency(stats?.total_mes || 0)}
-            </p>
-          </div>
-
-          <div className="flex flex-wrap items-end gap-2">
-            <div className="w-full sm:w-auto sm:min-w-[220px]">
-              <Input
-                type="month"
-                label="Mes de analisis"
-                value={selectedMonth}
-                disabled={historico}
-                max={getCurrentMonthValue()}
-                onChange={(event) => setSelectedMonth(event.target.value)}
-              />
+      {!sensitiveHidden && (
+        <div className="rounded-lg bg-card p-6 shadow-sm">
+          <div className="flex flex-wrap items-end justify-between gap-4">
+            <div>
+              <h2 className="mb-2 text-lg font-semibold text-text-primary">
+                {historico ? 'Total Facturado del Periodo' : 'Total Facturado del Mes'}
+              </h2>
+              <p className="text-4xl font-bold text-primary">
+                {formatCurrency(stats?.total_mes || 0)}
+              </p>
             </div>
-            <Button
-              variant={historico ? 'primary' : 'secondary'}
-              onClick={() => setHistorico((prev) => !prev)}
-            >
-              Historico
-            </Button>
+
+            <div className="flex flex-wrap items-end gap-2">
+              <div className="w-full sm:w-auto sm:min-w-[220px]">
+                <Input
+                  type="month"
+                  label="Mes de analisis"
+                  value={selectedMonth}
+                  disabled={historico}
+                  max={getCurrentMonthValue()}
+                  onChange={(event) => setSelectedMonth(event.target.value)}
+                />
+              </div>
+              <Button
+                variant={historico ? 'primary' : 'secondary'}
+                onClick={() => setHistorico((prev) => !prev)}
+              >
+                Historico
+              </Button>
+            </div>
           </div>
+          <p className="mt-3 text-sm text-text-secondary">
+            Periodo seleccionado: <span className="font-medium text-text-primary">{periodoLabel}</span>
+          </p>
         </div>
-        <p className="mt-3 text-sm text-text-secondary">
-          Periodo seleccionado: <span className="font-medium text-text-primary">{periodoLabel}</span>
-        </p>
-      </div>
+      )}
+
+      {sensitiveHidden && (
+        <div className="rounded-lg bg-card p-4 text-sm text-text-secondary shadow-sm">
+          El administrador restringió la visualización de métricas sensibles para tu usuario.
+        </div>
+      )}
 
       {/* Metrics Grid */}
       <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-4">
@@ -122,88 +134,92 @@ function Dashboard() {
         />
       </div>
 
-      <div className="grid gap-6 lg:grid-cols-2">
-        <div className="rounded-lg bg-card p-6 shadow-sm">
-          <div className="mb-4 flex items-center justify-between">
-            <h2 className="text-lg font-semibold text-text-primary">Facturacion mensual (12 meses)</h2>
-            <TrendingUp className="h-5 w-5 text-primary" />
+      {!sensitiveHidden && (
+        <>
+          <div className="grid gap-6 lg:grid-cols-2">
+            <div className="rounded-lg bg-card p-6 shadow-sm">
+              <div className="mb-4 flex items-center justify-between">
+                <h2 className="text-lg font-semibold text-text-primary">Facturacion mensual (12 meses)</h2>
+                <TrendingUp className="h-5 w-5 text-primary" />
+              </div>
+
+              <div className="space-y-3">
+                {trendData.map((item) => {
+                  const widthPercent = maxTrendTotal > 0 ? ((item.total || 0) / maxTrendTotal) * 100 : 0
+                  return (
+                    <div key={item.month}>
+                      <div className="mb-1 flex items-center justify-between gap-2 text-sm">
+                        <span className="text-text-secondary">{item.label}</span>
+                        <span className="font-medium text-text-primary">
+                          {formatCurrency(item.total || 0)} - {item.cantidad || 0} facturas
+                        </span>
+                      </div>
+                      <div className="h-2 rounded-full bg-secondary">
+                        <div
+                          className="h-2 rounded-full bg-primary transition-all"
+                          style={{ width: `${Math.max(widthPercent, 2)}%` }}
+                        />
+                      </div>
+                    </div>
+                  )
+                })}
+              </div>
+            </div>
+
+            <div className="rounded-lg bg-card p-6 shadow-sm">
+              <div className="mb-2 flex items-center justify-between">
+                <h2 className="text-lg font-semibold text-text-primary">Ticket promedio</h2>
+                <FileText className="h-5 w-5 text-primary" />
+              </div>
+              <p className="text-4xl font-bold text-primary">
+                {formatCurrency(ticket?.valor || 0)}
+              </p>
+              <p className="mt-2 text-sm text-text-secondary">
+                Total facturado: <span className="font-medium text-text-primary">{formatCurrency(ticket?.total || 0)}</span>
+                {' '}en <span className="font-medium text-text-primary">{ticket?.cantidad || 0}</span> facturas autorizadas
+              </p>
+              <p className={`mt-2 text-sm ${ticketVariation != null && ticketVariation >= 0 ? 'text-success' : 'text-text-secondary'}`}>
+                {ticketVariationLabel}
+              </p>
+            </div>
           </div>
 
-          <div className="space-y-3">
-            {trendData.map((item) => {
-              const widthPercent = maxTrendTotal > 0 ? ((item.total || 0) / maxTrendTotal) * 100 : 0
-              return (
-                <div key={item.month}>
-                  <div className="mb-1 flex items-center justify-between gap-2 text-sm">
-                    <span className="text-text-secondary">{item.label}</span>
-                    <span className="font-medium text-text-primary">
-                      {formatCurrency(item.total || 0)} - {item.cantidad || 0} facturas
-                    </span>
-                  </div>
-                  <div className="h-2 rounded-full bg-secondary">
-                    <div
-                      className="h-2 rounded-full bg-primary transition-all"
-                      style={{ width: `${Math.max(widthPercent, 2)}%` }}
-                    />
-                  </div>
-                </div>
-              )
-            })}
-          </div>
-        </div>
-
-        <div className="rounded-lg bg-card p-6 shadow-sm">
-          <div className="mb-2 flex items-center justify-between">
-            <h2 className="text-lg font-semibold text-text-primary">Ticket promedio</h2>
-            <FileText className="h-5 w-5 text-primary" />
-          </div>
-          <p className="text-4xl font-bold text-primary">
-            {formatCurrency(ticket?.valor || 0)}
-          </p>
-          <p className="mt-2 text-sm text-text-secondary">
-            Total facturado: <span className="font-medium text-text-primary">{formatCurrency(ticket?.total || 0)}</span>
-            {' '}en <span className="font-medium text-text-primary">{ticket?.cantidad || 0}</span> facturas autorizadas
-          </p>
-          <p className={`mt-2 text-sm ${ticketVariation != null && ticketVariation >= 0 ? 'text-success' : 'text-text-secondary'}`}>
-            {ticketVariationLabel}
-          </p>
-        </div>
-      </div>
-
-      <div className="rounded-lg bg-card p-6 shadow-sm">
-        <div className="mb-4 flex items-center justify-between">
-          <h2 className="text-lg font-semibold text-text-primary">Top 10 clientes por facturacion</h2>
-          <Users className="h-5 w-5 text-primary" />
-        </div>
-        <Table>
-          <TableHeader>
-            <TableRow>
-              <TableHead>Cliente</TableHead>
-              <TableHead>Documento</TableHead>
-              <TableHead>Cantidad</TableHead>
-              <TableHead>Total</TableHead>
-              <TableHead>% participacion</TableHead>
-            </TableRow>
-          </TableHeader>
-          <TableBody>
-            {topClientes.length === 0 ? (
-              <TableRow>
-                <TableCell colSpan={5} className="text-center text-text-muted">No hay datos para el periodo seleccionado</TableCell>
-              </TableRow>
-            ) : (
-              topClientes.map((cliente) => (
-                <TableRow key={cliente.receptor_id}>
-                  <TableCell className="font-medium">{cliente.razon_social}</TableCell>
-                  <TableCell>{cliente.doc_nro}</TableCell>
-                  <TableCell>{cliente.cantidad}</TableCell>
-                  <TableCell>{formatCurrency(cliente.total || 0)}</TableCell>
-                  <TableCell>{cliente.porcentaje?.toFixed?.(2) || '0.00'}%</TableCell>
+          <div className="rounded-lg bg-card p-6 shadow-sm">
+            <div className="mb-4 flex items-center justify-between">
+              <h2 className="text-lg font-semibold text-text-primary">Top 10 clientes por facturacion</h2>
+              <Users className="h-5 w-5 text-primary" />
+            </div>
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Cliente</TableHead>
+                  <TableHead>Documento</TableHead>
+                  <TableHead>Cantidad</TableHead>
+                  <TableHead>Total</TableHead>
+                  <TableHead>% participacion</TableHead>
                 </TableRow>
-              ))
-            )}
-          </TableBody>
-        </Table>
-      </div>
+              </TableHeader>
+              <TableBody>
+                {topClientes.length === 0 ? (
+                  <TableRow>
+                    <TableCell colSpan={5} className="text-center text-text-muted">No hay datos para el periodo seleccionado</TableCell>
+                  </TableRow>
+                ) : (
+                  topClientes.map((cliente) => (
+                    <TableRow key={cliente.receptor_id}>
+                      <TableCell className="font-medium">{cliente.razon_social}</TableCell>
+                      <TableCell>{cliente.doc_nro}</TableCell>
+                      <TableCell>{cliente.cantidad}</TableCell>
+                      <TableCell>{formatCurrency(cliente.total || 0)}</TableCell>
+                      <TableCell>{cliente.porcentaje?.toFixed?.(2) || '0.00'}%</TableCell>
+                    </TableRow>
+                  ))
+                )}
+              </TableBody>
+            </Table>
+          </div>
+        </>
+      )}
 
       {/* Quick Actions */}
       <div className="rounded-lg bg-card p-6 shadow-sm">


### PR DESCRIPTION
## Summary
- agrega restriccion individual por usuario para ocultar informacion sensible del dashboard (solo aplica a operator/viewer)
- incorpora check por usuario en la pestaña Usuarios y aplica ocultamiento de bloques sensibles en Dashboard con enforcement backend
- corrige fuga de cache entre sesiones incluyendo user id en query key y limpiando cache de React Query en login/logout

## Testing
- make test-backend
- make lint-frontend
- make build-frontend